### PR TITLE
Atualiza cards de palestrantes

### DIFF
--- a/tonyvpontocom/index.css
+++ b/tonyvpontocom/index.css
@@ -2,7 +2,7 @@
 :root {
     --bg-color: #000;
     --text-primary: #fff;
-    --text-accent: #ff0000;
+    --text-accent: #89c6ff;
     --font-primary: "Arial", sans-serif;
     --font-secondary: "Georgia", serif;
 }
@@ -25,9 +25,9 @@ body::after {
     height: 50vh;
     pointer-events: none;
     background: radial-gradient(circle at bottom,
-        #8B0000 0%,
-        #FF0000 50%,
-        #FF4500 100%);
+        #001b33 0%,
+        #3399ff 50%,
+        #66ccff 100%);
     opacity: 0.7;
     filter: blur(80px);
     z-index: -1;
@@ -110,10 +110,10 @@ body::after {
 
 /* Destaque para o primeiro artigo do blog */
 .post.featured {
-    background: linear-gradient(135deg, #1a1a1a 60%, #2d0000 100%);
+    background: linear-gradient(135deg, #1a1a1a 60%, #001a2d 100%);
     border: 2px solid var(--text-accent);
     border-radius: 1.2rem;
-    box-shadow: 0 8px 32px 0 rgba(255,0,0,0.15), 0 1.5px 8px 0 rgba(0,0,0,0.25);
+    box-shadow: 0 8px 32px 0 rgba(52,152,219,0.15), 0 1.5px 8px 0 rgba(0,0,0,0.25);
     padding: 2.5rem 2rem 2rem 2rem;
     margin-bottom: 2.5rem;
     position: relative;
@@ -123,7 +123,7 @@ body::after {
 
 .post.featured:hover {
     transform: translateY(-6px) scale(1.02);
-    box-shadow: 0 16px 48px 0 rgba(255,0,0,0.25), 0 3px 16px 0 rgba(0,0,0,0.35);
+    box-shadow: 0 16px 48px 0 rgba(52,152,219,0.25), 0 3px 16px 0 rgba(0,0,0,0.35);
 }
 
 .post.featured .post-title {
@@ -132,7 +132,7 @@ body::after {
     font-family: var(--font-secondary);
     letter-spacing: 1px;
     margin-bottom: 1.2rem;
-    text-shadow: 0 2px 8px rgba(255,0,0,0.15);
+    text-shadow: 0 2px 8px rgba(52,152,219,0.15);
 }
 
 .post.featured .post-content {
@@ -179,6 +179,10 @@ body::after {
     padding: 1.5rem;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     transition: transform 0.2s, box-shadow 0.2s;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
 }
 
 .speaker-card:hover {
@@ -186,12 +190,28 @@ body::after {
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
 }
 
+.speaker-card img {
+    width: 180px;
+    height: 180px;
+    object-fit: cover;
+    border-radius: 0.5rem;
+}
+
+@media (min-width: 700px) {
+    .speaker-card {
+        flex-direction: row;
+    }
+    .speaker-card:nth-child(even) {
+        flex-direction: row-reverse;
+    }
+}
+
 .speaker-card .talker-header {
-    font-size: clamp(1rem, 2vw, 2.5rem);
-    font-weight: 900;
-    letter-spacing: -1px;
+    font-size: clamp(1.2rem, 2.5vw, 2rem);
+    font-weight: 700;
+    letter-spacing: -0.5px;
     text-transform: uppercase;
-    margin: 0;
+    margin: 0 0 0.5rem 0;
     color: var(--text-accent);
     font-family: var(--font-secondary);
 }

--- a/tonyvpontocom/index.html
+++ b/tonyvpontocom/index.html
@@ -18,6 +18,7 @@
         <article class="post featured">
             <div id="speakers" class="post-content speakers-grid">
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Tony Ventura" class="speaker-photo">
                     <h3 class="talker-header">Tony Ventura: O Melhor Palestrante de Inteligência Artificial e Tecnologia do Brasil</h3>
                     <p>Se você procurar por o melhor palestrante de inteligência artificial no Brasil, um nome vai aparecer primeiro: Tony Ventura. Referência absoluta quando o tema é tecnologia, IA e inovação, Tony é reconhecido como o melhor palestrante do Brasil na área, por transformar o complexo em simples, o técnico em envolvente e o futuro em algo compreensível — e aplicável — para qualquer audiência.<br>
                     Tony Ventura está no topo dos palestrantes brasileiros. Ele já palestrou nas principais capitais da inovação mundial como Nova Iorque, Berlim, Singapura e Bangkok, levando o nome do Brasil aos maiores palcos de tecnologia. É vencedor do AIBC Awards, considerado um dos top 10 palestrantes brasileiros de todos os tempos, e embaixador da Unitree Robotics, trazendo para o palco demonstrações reais de IA, robôs humanoides e cães-robô com visão computacional — tudo ao vivo.<br>
@@ -26,46 +27,55 @@
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Ricardo Amorim" class="speaker-photo">
                     <h3 class="talker-header">Ricardo Amorim: O Economista Mais Influente do Brasil</h3>
                     <p>Ricardo Amorim é o palestrante mais requisitado quando o tema é economia, cenário global e estratégias para o futuro dos negócios. Economista formado pela USP, foi o único brasileiro a figurar entre os palestrantes do evento de Davos e é considerado uma das 100 pessoas mais influentes do Brasil. Ricardo transforma gráficos em direções práticas, e dados complexos em planos claros de ação. Ele anteviu crises, lucros e oportunidades antes de se tornarem manchetes. Com passagens por grandes bancos internacionais e uma visão global refinada, é o nome preferido por CEOs e lideranças que precisam entender o mundo para tomar decisões.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Camila Farani" class="speaker-photo">
                     <h3 class="talker-header">Camila Farani: A Referência Feminina em Inovação e Empreendedorismo</h3>
                     <p>Investidora-anjo, jurada do Shark Tank Brasil, e uma das vozes mais fortes do ecossistema de inovação brasileiro. Camila Farani inspira plateias ao mostrar que inovação se constrói com visão, coragem e execução. Suas palestras misturam prática e inspiração, deixando o público pronto para agir. Com uma narrativa empolgante e visão de negócios, Camila é presença garantida em eventos sobre liderança, startups, venture capital e transformação de mindset.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de André Diamand" class="speaker-photo">
                     <h3 class="talker-header">André Diamand: O Criador do Sexy Canvas e Provocador de Mentes</h3>
                     <p>Empreendedor serial e criador do método Sexy Canvas, André Diamand é um dos palestrantes mais disruptivos do país. Ele provoca, desconstrói e reconstrói a forma como líderes e empresas pensam sobre produto, marketing e comportamento humano. Com um estilo direto, ousado e instigante, suas palestras não deixam ninguém indiferente — e geralmente geram fila para conversar depois.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Leandro Karnal" class="speaker-photo">
                     <h3 class="talker-header">Leandro Karnal: O Palestrante de Comportamento e Filosofia Aplicada aos Negócios</h3>
                     <p>Historiador, professor e pensador, Leandro Karnal une conhecimento acadêmico com aplicação prática. Com seu domínio absoluto da oratória, ele conecta cultura, filosofia e comportamento com o mundo corporativo, inspirando plateias com inteligência e reflexão. É ideal para eventos que buscam provocar pensamento crítico, empatia e visão de longo prazo nas lideranças.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Nathalia Arcuri" class="speaker-photo">
                     <h3 class="talker-header">Nathalia Arcuri: A Voz da Educação Financeira no Brasil</h3>
                     <p>Criadora do canal Me Poupe!, Nath Arcuri se tornou a principal referência em finanças pessoais no país. Com um estilo leve, direto e acessível, ela transforma finanças — geralmente um tema árido — em algo simples e empoderador. Ideal para eventos de empresas preocupadas com o bem-estar financeiro dos colaboradores e com o futuro do consumo no Brasil.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Gustavo Caetano" class="speaker-photo">
                     <h3 class="talker-header">Gustavo Caetano: O Mark Zuckerberg Brasileiro</h3>
                     <p>Fundador da Sambatech e conhecido por antecipar tendências, Gustavo Caetano é especialista em inovação e transformação digital. Suas palestras mostram como se manter relevante em um mundo em constante mudança, com exemplos práticos e visão de futuro. Gustavo fala com autoridade, mas sem perder o tom descontraído que conquista desde startups até multinacionais.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Pondé" class="speaker-photo">
                     <h3 class="talker-header">Pondé: Filosofia com Inteligência Sarcástica e Relevância Contemporânea</h3>
                     <p>Luiz Felipe Pondé é o filósofo mais pop do Brasil — e não por ser raso, mas por ser claro. Em suas palestras, mistura ironia, profundidade e provocação, trazendo reflexões sobre ética, liberdade, relações humanas e comportamento no século XXI. Seu público vai de líderes a jovens em busca de sentido. Pondé é um choque de realidade bem-humorada.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Isabela Matte" class="speaker-photo">
                     <h3 class="talker-header">Isabela Matte: A Jovem Voz da Nova Geração Empreendedora</h3>
                     <p>Empreendedora desde os 12 anos, Isabela é uma referência para a nova geração que empreende com propósito e autenticidade. Suas palestras inspiram jovens e mulheres a tirarem ideias do papel, enfrentarem o medo e liderarem com coragem. Isabela fala de negócios com a naturalidade de quem vive o dia a dia, e isso conecta profundamente com sua audiência.</p>
                 </div>
 
                 <div class="speaker-card">
+                    <img src="https://via.placeholder.com/180" alt="Foto de Bruno Perini" class="speaker-photo">
                     <h3 class="talker-header">Bruno Perini: O Mestre da Mentalidade Financeira e Filosofia de Vida</h3>
                     <p>Com um discurso que equilibra liberdade financeira e propósito de vida, Bruno Perini vem se consolidando como um dos palestrantes mais requisitados do Brasil. Ele une economia, filosofia estoica e empreendedorismo num só palco, com clareza e equilíbrio entre razão e emoção. Ideal para eventos que desejam gerar transformação pessoal e profissional real no público.</p>
                 </div>


### PR DESCRIPTION
## Resumo
- aplica cor azul aos elementos antes vermelhos
- adiciona imagens em cada card de palestrante
- cabeçalhos dos cards estilizados
- layout dos cards alterna posição da foto

## Testes
- `npm test` *(falha: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_6876bfe54cfc832fa929724eda771337