### PR TITLE
Add missing carousel to clone1

### DIFF
--- a/clone1/index.html
+++ b/clone1/index.html
@@ -89,6 +89,26 @@
         <article class="post">
             <h2 class="post-title tecnologias-em-alta">Tecnologias em Alta</h2>
             <p class="post-content">tecnologias para converter clientes no seu evento.</p>
+            <div class="carousel-container">
+                <div class="carousel-track">
+                    <img src="./imagens/robohumanoide.png" alt="Robô humanoide da Unitree">
+                    <img src="./imagens/cachorrorobofoto.png"  alt="Cachorro robô da Unitree">
+                    <img src="./imagens/teslafoto.png"  alt="Tesla Cybertruck">
+                    <img src="./imagens/dronefoto.png"  alt="Drone de inteligência artificial">
+                    <img src="./imagens/robohumanoide.png" alt="Robô humanoide da Unitree">
+                    <img src="./imagens/cachorrorobofoto.png"  alt="Cachorro robô da Unitree">
+                    <img src="./imagens/teslafoto.png"  alt="Tesla Cybertruck">
+                    <img src="./imagens/dronefoto.png"  alt="Drone de inteligência artificial">
+                    <img src="./imagens/robohumanoide.png" alt="Robô humanoide da Unitree">
+                    <img src="./imagens/cachorrorobofoto.png"  alt="Cachorro robô da Unitree">
+                    <img src="./imagens/teslafoto.png"  alt="Tesla Cybertruck">
+                    <img src="./imagens/dronefoto.png"  alt="Drone de inteligência artificial">
+                    <img src="./imagens/robohumanoide.png" alt="Robô humanoide da Unitree">
+                    <img src="./imagens/cachorrorobofoto.png"  alt="Cachorro robô da Unitree">
+                    <img src="./imagens/teslafoto.png"  alt="Tesla Cybertruck">
+                    <img src="./imagens/dronefoto.png"  alt="Drone de inteligência artificial">
+                </div>
+            </div>
             <div class="cta">
                 <a class="whatsapp-button" href="https://wa.me/5561992983478" target="_blank">
                     quer uma dessas tecnologias no seu evento? entre em contato clicando aqui!


### PR DESCRIPTION
## Summary
- keep carousel on the clone1 page so it matches the other site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877a80790b4832f879af12a0005198d